### PR TITLE
CarrierWave::IntegrityError - Handle the scenario where we cancel an upload 

### DIFF
--- a/app/javascript/article-form/components/ImageUploader.jsx
+++ b/app/javascript/article-form/components/ImageUploader.jsx
@@ -14,12 +14,13 @@ export class ImageUploader extends Component {
   };
 
   handleInsertionImageUpload = e => {
-    this.clearUploadError();
+    const files = e.target.files;
 
+    this.clearUploadError();
     const validFileInputs = validateFileInputs();
 
-    if (validFileInputs) {
-      const payload = { image: e.target.files };
+    if (validFileInputs && files.length > 0) {
+      const payload = { image: files };
       generateMainImage(
         payload,
         this.handleInsertImageUploadSuccess,
@@ -34,7 +35,6 @@ export class ImageUploader extends Component {
     });
   };
 
-  
 
   clearUploadError = () => {
     this.setState({


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The way the uploads were being done previously forced you to upload only one image at the time, close the modal and then upload again, hence this error did not occur.

The error stems from the fact that we are validating files when there are no files to validate, hence we get a `CarrierWave::IntegrityError`.

The way to reproduce the bug is:
1. Click Upload an image, choose an image and upload
2. Click upload an image but this time do not choose an image an instead click cancel. You should see the error.
 
I've added a clause to first check if there are files to be upload before trying to process them.

@ludwiczakpawel I tested the interface with this change, can you please do a once over as well to ensure that it didn't have any unintended side effects. I'll try and see if its easily possibly to add a test for this after I'm done with the other stuff. 
 
## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [ ] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [ ] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
